### PR TITLE
Invoke originalDelegate's UITextFieldDelegate methods.

### DIFF
--- a/Sources/TransformingTextField/TransformingTextField.swift
+++ b/Sources/TransformingTextField/TransformingTextField.swift
@@ -181,9 +181,27 @@ extension TransformingTextFieldDelegate: UITextFieldDelegate {
         shouldChangeCharactersIn range: NSRange,
         replacementString string: String
     ) -> Bool {
+        originalDelegate?.textField(textField, shouldChangeCharactersIn: range, replacementString: string)
         replaceCharacters(in: range, with: string)
         // We already updated the text, binding and cursor position. Stop the default SwiftUI behavior.
         return false
+    }
+
+    public func textFieldDidBeginEditing(textField: UITextField) {
+        originalDelegate?.textFieldDidBeginEditing(textField)
+    }
+
+    public func textFieldDidEndEditing(_ textField: UITextField) {
+        originalDelegate?.textFieldDidEndEditing(textField)
+    }
+
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        originalDelegate?.textFieldShouldReturn(textField)
+        return true
+    }
+
+    public func textFieldDidChangeSelection(_ textField: UITextField) {
+        originalDelegate?.textFieldDidChangeSelection(textField)
     }
 }
 


### PR DESCRIPTION
The UITextFieldDelegate's methods of the originalDelegate are not invoked. This means that the local logic for example for func textFieldDidEndEditing(_ textField: UITextField) will not be executed and the modifier will change the behaviour of the TextField used in the app.
In this PR I've only added the methods used in the MoBa app, but probably in future all methods of the UITextFieldDelegate should be added.