### PR TITLE
Prevent multiple calls with the same replacement string

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,14 +1,16 @@
 {
-  "pins" : [
-    {
-      "identity" : "swiftui-introspect",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/siteline/swiftui-introspect",
-      "state" : {
-        "revision" : "ccb973cfff703cba53fb88197413485c060eb26b",
-        "version" : "0.10.0"
+  "object": {
+    "pins": [
+      {
+        "package": "swiftui-introspect",
+        "repositoryURL": "https://github.com/siteline/swiftui-introspect",
+        "state": {
+          "branch": null,
+          "revision": "ccb973cfff703cba53fb88197413485c060eb26b",
+          "version": "0.10.0"
+        }
       }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Sources/TransformingTextField/TransformingTextFieldDelegate+UITextFieldDelegate.swift
+++ b/Sources/TransformingTextField/TransformingTextFieldDelegate+UITextFieldDelegate.swift
@@ -12,6 +12,16 @@ extension TransformingTextFieldDelegate: UITextFieldDelegate {
     func textField(
         _ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String
     ) -> Bool {
+        // Framework bug workaround:
+        // Prevent multiple calls with the same replacement string when the user accepts an autocorrect suggestion
+        if textField.autocorrectionType != .no, string == lastReplacementString,
+           -lastReplacementDate.timeIntervalSinceNow < 0.3
+        {
+            return false
+        }
+        lastReplacementString = string
+        lastReplacementDate = Date()
+
         replaceCharacters(in: range, with: string)
         // We already updated the text, binding and cursor position. Stop the default SwiftUI behavior.
         return false


### PR DESCRIPTION
- Framework bug workaround: Prevent multiple calls with the same replacement string
- Refactor range handling